### PR TITLE
fix: author description line height

### DIFF
--- a/_sass/layouts/_index.scss
+++ b/_sass/layouts/_index.scss
@@ -105,7 +105,7 @@
   color: rgba($text-color, .6);
   letter-spacing: 0.1em;
   font-size: 0.7em;
-
+  line-height: 1.5em;
 }
 
 // Pagination


### PR DESCRIPTION
author description의 `line-height` 추가합니다. 

### AS-IS
<img src="https://user-images.githubusercontent.com/20153890/91166604-92b2bd80-e70d-11ea-92d7-d647bd3f17f5.png" width=800>

### TO-BE
<img src="https://user-images.githubusercontent.com/20153890/91166584-8a5a8280-e70d-11ea-985e-572fb7d27345.png" width=800>
